### PR TITLE
ノートブック全体でフリーズ要否を設定する

### DIFF
--- a/lc_run_through/nbextension/main.js
+++ b/lc_run_through/nbextension/main.js
@@ -30,7 +30,7 @@ define([
             setTimeout(function() {
                 var status = get_state(data.cell);
                 if (status.frozen || status.read_only || status.frozenable) {
-                    set_state(data.cell, {frozen: false, read_only: false, frozenable: false});
+                    set_state(data.cell, {frozen: false, read_only: false});
                 }
             }, 0);
         });
@@ -498,9 +498,9 @@ define([
     function finished_execute(cell, status) {
         var index = Jupyter.notebook.find_cell_index(cell);
         console.log("[run_through] cell execution finished: index=%s, status=%s", index, status);
-        var flozenable = is_frozenable(cell)
+        var frozenable = is_frozenable(cell)
         if (status == "ok") {
-            if (flozenable) {
+            if (frozenable) {
                 console.log('[run_through] freeze executed cell: %d', index);
                 freeze_cell(cell);
             }
@@ -564,9 +564,13 @@ define([
     }
 
     function is_frozenable(cell) {
-        if ((cell instanceof codecell.CodeCell || cell instanceof textcell.MarkdownCell) &&
-            (cell.metadata.run_through_control !== undefined)) {
+        if (cell instanceof codecell.CodeCell || cell instanceof textcell.MarkdownCell) {
+            if (cell.metadata.run_through_control !== undefined) {
                 return cell.metadata.run_through_control.frozenable === true ? true : false
+            }
+            if (Jupyter.notebook.metadata.frozenable !== undefined) {
+                return Jupyter.notebook.metadata.frozenable === true ? true : false
+            }
         }
         return false
     }

--- a/lc_run_through/nbextension/main.js
+++ b/lc_run_through/nbextension/main.js
@@ -29,7 +29,7 @@ define([
             cell_appended(data.cell);
             setTimeout(function() {
                 var status = get_state(data.cell);
-                if (status.frozen || status.read_only || status.frozenable) {
+                if (status.frozen || status.read_only) {
                     set_state(data.cell, {frozen: false, read_only: false});
                 }
             }, 0);
@@ -565,7 +565,7 @@ define([
 
     function is_frozenable(cell) {
         if (cell instanceof codecell.CodeCell || cell instanceof textcell.MarkdownCell) {
-            if (cell.metadata.run_through_control !== undefined) {
+            if (cell.metadata.run_through_control.frozenable !== undefined) {
                 return cell.metadata.run_through_control.frozenable === true ? true : false
             }
             if (Jupyter.notebook.metadata.frozenable !== undefined) {

--- a/lc_run_through/nbextension/main.js
+++ b/lc_run_through/nbextension/main.js
@@ -565,7 +565,7 @@ define([
 
     function is_frozenable(cell) {
         if (cell instanceof codecell.CodeCell || cell instanceof textcell.MarkdownCell) {
-            if (cell.metadata.run_through_control.frozenable !== undefined) {
+            if (cell.metadata.run_through_control !== undefined) {
                 return cell.metadata.run_through_control.frozenable === true ? true : false
             }
             if (Jupyter.notebook.metadata.frozenable !== undefined) {


### PR DESCRIPTION
## Background

* フリーズするかしないかを、セル単位だけでなく、ノートブック単位で設定できるようにしたい

## Main Points of Modification

* "frozenable"というメタデータをtrueで設定したノートブックまたはセルでフリーズが機能するようにした
* ノートブックとセルの両方で設定されている場合には、セルに設定されたものを優先する

## Test

* ノートブックにメタデータを設定する
![image](https://github.com/user-attachments/assets/acd9431e-273e-4b44-95cc-1ee3f9c671c1)
フリーズする
![image](https://github.com/user-attachments/assets/9facde7f-a8d0-4337-963c-f68dc5b06be2)

* 上記のまま、セルのメタデータでフリーズしないように設定する
![image](https://github.com/user-attachments/assets/85652cdb-0dcb-4732-8b39-817abdbfacb2)
メタデータを設定したセルのみがフリーズしなくなる
![image](https://github.com/user-attachments/assets/c903a610-42ef-4d0e-9f32-de537a6418eb)

* ノートブックにはメタデータを設定しないで、特定のセルだけフリーズするようにする
メタデータを設定したセルだけフリーズする
